### PR TITLE
Fix markup on z3c input fields

### DIFF
--- a/plonetheme/nuplone/z3cform/templates/checkbox_input.pt
+++ b/plonetheme/nuplone/z3cform/templates/checkbox_input.pt
@@ -4,7 +4,6 @@
       i18n:domain="nuplone"
       tal:omit-tag=""
       tal:define="item python:view.items[0]">
-<div class="z3cFieldContainer ${view/@@dependencies}">
   <label class="${python:'error' if view.error is not None else None}" ><tal:span replace="item/label">Widget label</tal:span> <sup tal:condition="view/required" class="required">*</sup>
     <input type="checkbox" tal:define="checked item/checked" id="${view/id}"
            name="${item/name}" value="${item/value}"
@@ -13,5 +12,4 @@
            readonly="${view/readonly}"/><tal:error condition="view/error" replace="structure view/error/render|nothing"/></label>
     <input type="hidden" value="1" name="${view/name}-empty-marker" />
     <dfn class="infoPanel" i18n:attributes="title" title="Information" tal:define="description view/field/description" tal:condition="description">${description}</dfn>
-</div>
 </html>

--- a/plonetheme/nuplone/z3cform/templates/checkbox_input.pt
+++ b/plonetheme/nuplone/z3cform/templates/checkbox_input.pt
@@ -4,6 +4,7 @@
       i18n:domain="nuplone"
       tal:omit-tag=""
       tal:define="item python:view.items[0]">
+<span class="${view/@@dependencies}" tal:omit-tag="not:view/@@dependencies">
   <label class="${python:'error' if view.error is not None else None}" ><tal:span replace="item/label">Widget label</tal:span> <sup tal:condition="view/required" class="required">*</sup>
     <input type="checkbox" tal:define="checked item/checked" id="${view/id}"
            name="${item/name}" value="${item/value}"
@@ -12,4 +13,5 @@
            readonly="${view/readonly}"/><tal:error condition="view/error" replace="structure view/error/render|nothing"/></label>
     <input type="hidden" value="1" name="${view/name}-empty-marker" />
     <dfn class="infoPanel" i18n:attributes="title" title="Information" tal:define="description view/field/description" tal:condition="description">${description}</dfn>
+</span>
 </html>

--- a/plonetheme/nuplone/z3cform/templates/namedfile_input.pt
+++ b/plonetheme/nuplone/z3cform/templates/namedfile_input.pt
@@ -4,11 +4,9 @@
       i18n:domain="nuplone"
       tal:define="download_url view/download_url;"
       tal:omit-tag="">
-<div class="${view/@@dependencies} z3cFieldContainer">
   <label class="${python:'error' if view.error is not None else None}">${view/label} <sup tal:condition="view/required" class="required">*</sup>
     <span tal:condition="view/allow_nochange"><a href="${view/download_url}">${view/filename}</a> (${view/file_size}kB)</span>
     <input type="file" id="${view/id}" name="${view/name}" class="${view/klass}" disabled="${view/disabled}" readonly="${view/readonly}"/> <tal:error condition="view/error" replace="structure view/error/render|nothing"/></label>
     <dfn class="infoPanel" i18n:attributes="title" title="Information" tal:define="description view/field/description" tal:condition="description">${description}</dfn>
-</div>
 </html>
 

--- a/plonetheme/nuplone/z3cform/templates/namedfile_input.pt
+++ b/plonetheme/nuplone/z3cform/templates/namedfile_input.pt
@@ -4,9 +4,11 @@
       i18n:domain="nuplone"
       tal:define="download_url view/download_url;"
       tal:omit-tag="">
+<span class="${view/@@dependencies}" tal:omit-tag="not:view/@@dependencies">
   <label class="${python:'error' if view.error is not None else None}">${view/label} <sup tal:condition="view/required" class="required">*</sup>
     <span tal:condition="view/allow_nochange"><a href="${view/download_url}">${view/filename}</a> (${view/file_size}kB)</span>
     <input type="file" id="${view/id}" name="${view/name}" class="${view/klass}" disabled="${view/disabled}" readonly="${view/readonly}"/> <tal:error condition="view/error" replace="structure view/error/render|nothing"/></label>
     <dfn class="infoPanel" i18n:attributes="title" title="Information" tal:define="description view/field/description" tal:condition="description">${description}</dfn>
+</span>
 </html>
 

--- a/plonetheme/nuplone/z3cform/templates/password_input.pt
+++ b/plonetheme/nuplone/z3cform/templates/password_input.pt
@@ -3,7 +3,9 @@
       xmlns:i18n="http://xml.zope.org/namespaces/i18n"
       i18n:domain="nuplone"
       tal:omit-tag="">
+<span class="${view/@@dependencies}" tal:omit-tag="not:view/@@dependencies">
   <label class="${python:'error' if view.error is not None else None}">${view/label} <sup tal:condition="view/required" class="required">*</sup>
     <input type="password" id="${view/id}" name="${view/name}" value="${view/value}" class="${view/klass}" disabled="${view/disabled}" readonly="${view/readonly}" size="${view/size}" maxlength="${view/maxlength"/> <tal:error condition="view/error" replace="structure view/error/render|nothing"/></label>
   <dfn class="infoPanel" i18n:attributes="title" title="Information" tal:define="description view/field/description" tal:condition="description">${description}</dfn>
+</span>
 </html>

--- a/plonetheme/nuplone/z3cform/templates/password_input.pt
+++ b/plonetheme/nuplone/z3cform/templates/password_input.pt
@@ -3,10 +3,7 @@
       xmlns:i18n="http://xml.zope.org/namespaces/i18n"
       i18n:domain="nuplone"
       tal:omit-tag="">
-<div class="${view/@@dependencies} z3cFieldContainer">
   <label class="${python:'error' if view.error is not None else None}">${view/label} <sup tal:condition="view/required" class="required">*</sup>
     <input type="password" id="${view/id}" name="${view/name}" value="${view/value}" class="${view/klass}" disabled="${view/disabled}" readonly="${view/readonly}" size="${view/size}" maxlength="${view/maxlength"/> <tal:error condition="view/error" replace="structure view/error/render|nothing"/></label>
   <dfn class="infoPanel" i18n:attributes="title" title="Information" tal:define="description view/field/description" tal:condition="description">${description}</dfn>
-</div>
 </html>
-

--- a/plonetheme/nuplone/z3cform/templates/passwordconfirm_input.pt
+++ b/plonetheme/nuplone/z3cform/templates/passwordconfirm_input.pt
@@ -3,11 +3,13 @@
       xmlns:i18n="http://xml.zope.org/namespaces/i18n"
       i18n:domain="nuplone"
       tal:omit-tag="">
+<span class="${view/@@dependencies}" tal:omit-tag="not:view/@@dependencies">
   <label class="${python:'error' if view.error is not None else None}">${view/label} <sup tal:condition="view/required" class="required">*</sup>
     <input type="password" id="${view/id}" name="${view/name}" class="${view/klass}" disabled="${view/disabled}" readonly="${view/readonly}" size="${view/size}" maxlength="${view/maxlength}"/> <tal:error condition="view/error" replace="structure view/error/render|nothing"/></label>
   <dfn class="infoPanel" i18n:attributes="title" title="Information" tal:define="description view/field/description" tal:condition="description">${description}</dfn>
   <label><tal:span i18n:translate="">Confirm password</tal:span>
     <input type="password" id="${view/id}.confirm" name="${view/name}.confirm" class="${view/klass}" disabled="${view/disabled}" readonly="${view/readonly}" size="${view/size}" maxlength="${view/maxlength}"/>
     </label>
+</span>
 </html>
 

--- a/plonetheme/nuplone/z3cform/templates/passwordconfirm_input.pt
+++ b/plonetheme/nuplone/z3cform/templates/passwordconfirm_input.pt
@@ -3,13 +3,11 @@
       xmlns:i18n="http://xml.zope.org/namespaces/i18n"
       i18n:domain="nuplone"
       tal:omit-tag="">
-<div class="${view/@@dependencies} z3cFieldContainer">
   <label class="${python:'error' if view.error is not None else None}">${view/label} <sup tal:condition="view/required" class="required">*</sup>
     <input type="password" id="${view/id}" name="${view/name}" class="${view/klass}" disabled="${view/disabled}" readonly="${view/readonly}" size="${view/size}" maxlength="${view/maxlength}"/> <tal:error condition="view/error" replace="structure view/error/render|nothing"/></label>
   <dfn class="infoPanel" i18n:attributes="title" title="Information" tal:define="description view/field/description" tal:condition="description">${description}</dfn>
   <label><tal:span i18n:translate="">Confirm password</tal:span>
     <input type="password" id="${view/id}.confirm" name="${view/name}.confirm" class="${view/klass}" disabled="${view/disabled}" readonly="${view/readonly}" size="${view/size}" maxlength="${view/maxlength}"/>
     </label>
-</div>
 </html>
 

--- a/plonetheme/nuplone/z3cform/templates/select_input.pt
+++ b/plonetheme/nuplone/z3cform/templates/select_input.pt
@@ -3,6 +3,7 @@
       xmlns:i18n="http://xml.zope.org/namespaces/i18n"
       i18n:domain="nuplone"
       tal:omit-tag="">
+<span class="${view/@@dependencies}" tal:omit-tag="not:view/@@dependencies">
   <label class="${python:'error' if view.error is not None else None}">${view/label} <sup tal:condition="view/required" class="required">*</sup>
     <select id="${view/id}" name="${view/name}" class="${view/klass}" multiple="${view/multiple}" size="${view/size}">
       <tal:item repeat="item view/items"><option tal:define="selected item/selected" id="${item/id}" value="${item/value}" selected="${python:'selected' if selected else None}">${item/content}</option></tal:item>
@@ -10,6 +11,7 @@
   <tal:error condition="view/error" replace="structure view/error/render|nothing"/> </label>
 <dfn class="infoPanel" i18n:attributes="title" title="Information" tal:define="description view/field/description" tal:condition="description">${description}</dfn>
   <input type="hidden" value="1" name="${view/name}-empty-marker" />
+</span>
 </html>
 
 

--- a/plonetheme/nuplone/z3cform/templates/select_input.pt
+++ b/plonetheme/nuplone/z3cform/templates/select_input.pt
@@ -3,7 +3,6 @@
       xmlns:i18n="http://xml.zope.org/namespaces/i18n"
       i18n:domain="nuplone"
       tal:omit-tag="">
-<div class="${view/@@dependencies} z3cFieldContainer">
   <label class="${python:'error' if view.error is not None else None}">${view/label} <sup tal:condition="view/required" class="required">*</sup>
     <select id="${view/id}" name="${view/name}" class="${view/klass}" multiple="${view/multiple}" size="${view/size}">
       <tal:item repeat="item view/items"><option tal:define="selected item/selected" id="${item/id}" value="${item/value}" selected="${python:'selected' if selected else None}">${item/content}</option></tal:item>
@@ -11,7 +10,6 @@
   <tal:error condition="view/error" replace="structure view/error/render|nothing"/> </label>
 <dfn class="infoPanel" i18n:attributes="title" title="Information" tal:define="description view/field/description" tal:condition="description">${description}</dfn>
   <input type="hidden" value="1" name="${view/name}-empty-marker" />
-</div>
 </html>
 
 

--- a/plonetheme/nuplone/z3cform/templates/text_input.pt
+++ b/plonetheme/nuplone/z3cform/templates/text_input.pt
@@ -3,13 +3,11 @@
       xmlns:i18n="http://xml.zope.org/namespaces/i18n"
       i18n:domain="nuplone"
       tal:omit-tag="">
-<div class="z3cFieldContainer ${view/@@dependencies}">
   <label class="${python:'error' if view.error is not None else None}">${view/label} <sup tal:condition="view/required" class="required">*</sup>
       <input type="text" id="${view/id}" name="${view/name}" value="${view/value}"
              class="${view/klass}" disabled="${view/disabled}"
              readonly="${view/readonly}" size="${view/size}"
              maxlength="${view/maxlength}"/><tal:error condition="view/error" replace="structure view/error/render|nothing"/></label>
      <dfn class="infoPanel" i18n:attributes="title" title="Information" tal:define="description view/field/description" tal:condition="description">${description}</dfn>
-</div>
 </html>
 

--- a/plonetheme/nuplone/z3cform/templates/text_input.pt
+++ b/plonetheme/nuplone/z3cform/templates/text_input.pt
@@ -3,11 +3,13 @@
       xmlns:i18n="http://xml.zope.org/namespaces/i18n"
       i18n:domain="nuplone"
       tal:omit-tag="">
+<span class="${view/@@dependencies}" tal:omit-tag="not:view/@@dependencies">
   <label class="${python:'error' if view.error is not None else None}">${view/label} <sup tal:condition="view/required" class="required">*</sup>
       <input type="text" id="${view/id}" name="${view/name}" value="${view/value}"
              class="${view/klass}" disabled="${view/disabled}"
              readonly="${view/readonly}" size="${view/size}"
              maxlength="${view/maxlength}"/><tal:error condition="view/error" replace="structure view/error/render|nothing"/></label>
      <dfn class="infoPanel" i18n:attributes="title" title="Information" tal:define="description view/field/description" tal:condition="description">${description}</dfn>
+</span>
 </html>
 

--- a/plonetheme/nuplone/z3cform/templates/textarea_input.pt
+++ b/plonetheme/nuplone/z3cform/templates/textarea_input.pt
@@ -5,11 +5,9 @@
       i18n:domain="nuplone"
       meta:interpolation="true"
       tal:omit-tag="">
-<div class="z3cFieldContainer ${view/@@dependencies}">
-  <label class="${python:'error' if view.error is not None else None}">${view/label}<sup tal:condition="view/required" class="required">*</sup> 
+  <label class="${python:'error' if view.error is not None else None}">${view/label}<sup tal:condition="view/required" class="required">*</sup>
     <textarea id="${view/id}" name="${view/name}" class="${view/klass}" disabled="${view/disabled}" readonly="${view/readonly}" cols="${view/cols}" rows="${view/rows}">${view/value}</textarea>
     <tal:error condition="view/error" replace="structure view/error/render|nothing"/></label>
   <dfn class="infoPanel" i18n:attributes="title" title="Information" tal:define="description view/field/description" tal:condition="description">${description}</dfn>
-</div>
 </html>
 

--- a/plonetheme/nuplone/z3cform/templates/textarea_input.pt
+++ b/plonetheme/nuplone/z3cform/templates/textarea_input.pt
@@ -5,9 +5,11 @@
       i18n:domain="nuplone"
       meta:interpolation="true"
       tal:omit-tag="">
+<span class="${view/@@dependencies}" tal:omit-tag="not:view/@@dependencies">
   <label class="${python:'error' if view.error is not None else None}">${view/label}<sup tal:condition="view/required" class="required">*</sup>
     <textarea id="${view/id}" name="${view/name}" class="${view/klass}" disabled="${view/disabled}" readonly="${view/readonly}" cols="${view/cols}" rows="${view/rows}">${view/value}</textarea>
     <tal:error condition="view/error" replace="structure view/error/render|nothing"/></label>
   <dfn class="infoPanel" i18n:attributes="title" title="Information" tal:define="description view/field/description" tal:condition="description">${description}</dfn>
+</span>
 </html>
 

--- a/plonetheme/nuplone/z3cform/templates/textlines_input.pt
+++ b/plonetheme/nuplone/z3cform/templates/textlines_input.pt
@@ -3,11 +3,9 @@
       xmlns:i18n="http://xml.zope.org/namespaces/i18n"
       i18n:domain="nuplone"
       tal:omit-tag="">
-<div class="${view/@@dependencies} z3cFieldContainer">
   <label class="${python:'error' if view.error is not None else None}">${view/label} <sup tal:condition="view/required" class="required">*</sup>
     <textarea id="${view/id}" name="${view/name}" class="${view/klass}" disabled="${view/disabled}" readonly="${view/readonly}" cols="${view/cols}" rows="${view/rows}" tal:content="structure view/value" />
       <tal:error condition="view/error" replace="structure view/error/render|nothing"/></label>
-    <dfn class="infoPanel" i18n:attributes="title" title="Information" tal:define="description view/field/description" tal:condition="description">${description}</dfn> 
-</div>
+    <dfn class="infoPanel" i18n:attributes="title" title="Information" tal:define="description view/field/description" tal:condition="description">${description}</dfn>
 </html>
 

--- a/plonetheme/nuplone/z3cform/templates/textlines_input.pt
+++ b/plonetheme/nuplone/z3cform/templates/textlines_input.pt
@@ -3,9 +3,11 @@
       xmlns:i18n="http://xml.zope.org/namespaces/i18n"
       i18n:domain="nuplone"
       tal:omit-tag="">
+<span class="${view/@@dependencies}" tal:omit-tag="not:view/@@dependencies">
   <label class="${python:'error' if view.error is not None else None}">${view/label} <sup tal:condition="view/required" class="required">*</sup>
     <textarea id="${view/id}" name="${view/name}" class="${view/klass}" disabled="${view/disabled}" readonly="${view/readonly}" cols="${view/cols}" rows="${view/rows}" tal:content="structure view/value" />
       <tal:error condition="view/error" replace="structure view/error/render|nothing"/></label>
     <dfn class="infoPanel" i18n:attributes="title" title="Information" tal:define="description view/field/description" tal:condition="description">${description}</dfn>
+</span>
 </html>
 


### PR DESCRIPTION
get rid of unnecessary and unwanted `<div>` with class z3cFieldContainer around some input widgets