### PR TITLE
Update package and fix broken settings_url property

### DIFF
--- a/buildout.cfg
+++ b/buildout.cfg
@@ -10,7 +10,7 @@ develop = .
 
 [tools]
 recipe = zc.recipe.egg
-interpreter = python
+interpreter = pytools
 eggs =
     coverage
     lingua

--- a/plonetheme/nuplone/skin/sitemenu.py
+++ b/plonetheme/nuplone/skin/sitemenu.py
@@ -1,16 +1,16 @@
-from five import grok
-from zope.interface import Interface
-
 from Acquisition import aq_inner
+from five import grok
 from OFS.interfaces import ICopyContainer
-
-from Products.CMFCore.ActionInformation import ActionInfo
-from Products.CMFCore.interfaces import ISiteRoot
-from Products.CMFCore.utils import getToolByName
-
+from plone.memoize.view import memoize_contextless
 from plonetheme.nuplone import MessageFactory as _
 from plonetheme.nuplone.skin.interfaces import NuPloneSkin
 from plonetheme.nuplone.utils import getFactoriesInContext
+from Products.CMFCore.ActionInformation import ActionInfo
+from Products.CMFCore.interfaces import ISiteRoot
+from Products.CMFCore.utils import getToolByName
+from zope.component import getMultiAdapter
+from zope.interface import Interface
+
 
 grok.templatedir("templates")
 
@@ -22,8 +22,13 @@ class Sitemenu(grok.View):
     grok.template("sitemenu")
 
     @property
+    @memoize_contextless
+    def tools_view(self):
+        return getMultiAdapter((self.context, self.request,), name='tools')
+
+    @property
     def settings_url(self):
-        return "%s/@@settings" % self.navroot_url
+        return "%s/@@settings" % self.tools_view.navroot_url
 
     def update(self):
         self.view_type = self.request.get("view_type", "view")

--- a/plonetheme/nuplone/skin/tests/test_sitemenu.py
+++ b/plonetheme/nuplone/skin/tests/test_sitemenu.py
@@ -1,14 +1,35 @@
-import unittest2 as unittest
-import zope.component
-from zope.interface import alsoProvides
-from plone.testing import z2
 from plone.app.testing import login
-from plone.app.testing import TEST_USER_NAME
+from plone.app.testing import setRoles
 from plone.app.testing import SITE_OWNER_NAME
 from plone.app.testing import TEST_USER_ID
-from plone.app.testing import setRoles
+from plone.app.testing import TEST_USER_NAME
+from plone.testing import z2
 from plonetheme.nuplone.skin.interfaces import NuPloneSkin
 from plonetheme.nuplone.testing import NUPLONE_FUNCTIONAL_TESTING
+from plonetheme.nuplone.testing import NUPLONE_INTEGRATION_TESTING
+from zope.interface import alsoProvides
+
+import unittest2 as unittest
+import zope.component
+
+
+class SiteMenuIntegrationTests(unittest.TestCase):
+    layer = NUPLONE_INTEGRATION_TESTING
+
+    def setUp(self):
+        self.portal = self.layer["portal"]
+        self.request = self.portal.REQUEST
+        alsoProvides(self.request, NuPloneSkin)
+
+    def test_settings_url(self):
+        ''' Check that the sitemenu view provides a settings_url attribute
+        '''
+        view = zope.component.getMultiAdapter(
+            (self.portal, self.request),
+            name="sitemenu",
+        )
+        self.assertEqual(view.settings_url, 'http://nohost/plone/@@settings')
+
 
 class SiteMenuTests(unittest.TestCase):
     layer = NUPLONE_FUNCTIONAL_TESTING


### PR DESCRIPTION
When you create a Plone 4.2.4 site and install NuPlone you get a:
```
LocationError: (<plonetheme.nuplone.skin.sitemenu.Sitemenu object at 0x7fa0dc6bfe50>, 'settings_url')
```