### PR TITLE
Improve URLs in page templates

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -4,7 +4,7 @@ Changelog
 1.5.7 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- More efficient and safe url definition in templates
 
 
 1.5.6 (2017-11-27)

--- a/plonetheme/nuplone/skin/templates/layout.pt
+++ b/plonetheme/nuplone/skin/templates/layout.pt
@@ -8,10 +8,15 @@
       meta:interpolation="true"
       metal:define-macro="layout"
       i18n:domain="nuplone"
-      tal:define="tools context/@@tools">
-  <head tal:define="style_url tools/portal/++resource++NuPlone.style">
+      tal:condition="portal_url"
+      tal:define="
+        tools nocall:context/@@tools;
+        portal_url tools/portal_url|nothing;
+      "
+>
+  <head tal:define="style_url string:${portal_url}/++resource++NuPlone.style">
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-    <script type="text/javascript" src="${tools/portal/++resource++NuPlone.libraries}/css_browser_selector.js"></script>
+    <script type="text/javascript" src="${portal_url}/++resource++NuPlone.libraries/css_browser_selector.js"></script>
     <link rel="stylesheet" type="text/css" media="all" href="${style_url}/main/base.css" />
     <!--[if IE 6]> <link rel="stylesheet" type="text/css" media="all" href="${style_url}/main/base-ie6.css" /> <![endif]-->
     <!--[if IE 7]> <link rel="stylesheet" type="text/css" media="all" href="${style_url}/main/base-ie7.css" /> <![endif]-->
@@ -46,17 +51,16 @@
     <tal:block replace="tile:actions"/>
     <tal:block replace="tile:footer"/>
     <script type="text/javascript">
-      var plone = { portal_url : '${tools/portal/absolute_url}',
+      var plone = { portal_url : '${portal_url}',
                     context_url : '${context/absolute_url}' };
     </script>
-    <script type="text/javascript" src="${tools/portal/++resource++NuPlone.libraries}/jquery-1.11.3.min.js"></script>
-    <script type="text/javascript" src="${tools/portal/++resource++NuPlone.libraries}/jquery.browser.min.js"></script>
-    <!-- <script type="text/javascript" src="${tools/portal/++resource++NuPlone.libraries}/jquery.tools.min.js"></script> -->
-    <script type="text/javascript" src="${tools/portal/++resource++NuPlone.libraries}/ui-1.11.4/jquery-ui.min.js"></script>
-    <script type="text/javascript" src="${tools/portal/++resource++NuPlone.tinymce}/tiny_mce_src.js"></script>
-    <script type="text/javascript" src="${tools/portal/++resource++NuPlone.z3cform.js}"></script>
-    <script type="text/javascript" src="${tools/portal/++resource++NuPlone.behaviour}/behaviour.js"></script>
-    <script type="text/javascript" src="${tools/portal/++resource++NuPlone.libraries}/ordering.js"></script>
+    <script type="text/javascript" src="${portal_url}/++resource++NuPlone.libraries/jquery-1.11.3.min.js"></script>
+    <script type="text/javascript" src="${portal_url}/++resource++NuPlone.libraries/jquery.browser.min.js"></script>
+    <script type="text/javascript" src="${portal_url}/++resource++NuPlone.libraries/ui-1.11.4/jquery-ui.min.js"></script>
+    <script type="text/javascript" src="${portal_url}/++resource++NuPlone.tinymce/tiny_mce_src.js"></script>
+    <script type="text/javascript" src="${portal_url}/++resource++NuPlone.z3cform.js"></script>
+    <script type="text/javascript" src="${portal_url}/++resource++NuPlone.behaviour/behaviour.js"></script>
+    <script type="text/javascript" src="${portal_url}/++resource++NuPlone.libraries/ordering.js"></script>
     <tal:block replace="tile:scripts"/>
     <metal:block define-slot="scripts"/>
   </body>

--- a/plonetheme/nuplone/skin/templates/sitemenu.pt
+++ b/plonetheme/nuplone/skin/templates/sitemenu.pt
@@ -6,10 +6,10 @@
       xmlns:meta="http://xml.zope.org/namespaces/meta"
       meta:interpolation="true"
       i18n:domain="nuplone"
-      tal:define="tools context/@@tools; factories view/factories">
+      tal:define="tools context/@@tools; factories view/factories; portal_url tools/portal_url|nothing;">
   <head tal:define="style_url tools/portal/++resource++NuPlone.style">
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-    <script type="text/javascript" src="${tools/portal/++resource++NuPlone.libraries}/css_browser_selector.js"></script>
+    <script type="text/javascript" src="${portal_url}/++resource++NuPlone.libraries/css_browser_selector.js"></script>
     <link rel="stylesheet" type="text/css" media="all" href="${style_url}/main/base.css" />
     <!--[if IE 6]> <link rel="stylesheet" type="text/css" media="screen" href="${style_url}/main/base-ie6.css" /> <![endif]-->
     <!--[if IE 7]> <link rel="stylesheet" type="text/css" media="screen" href="${style_url}/main/base-ie7.css" /> <![endif]-->
@@ -54,9 +54,9 @@
       </tal:block>
     </ul>
 
-  <script type="text/javascript" src="${tools/portal/++resource++NuPlone.libraries}/jquery-1.11.3.min.js"></script>
-    <script type="text/javascript" src="${tools/portal/++resource++NuPlone.libraries}/jquery.browser.min.js"></script>
-  <script type="text/javascript" src="${tools/portal/++resource++NuPlone.behaviour}/behaviour.js"></script>
+  <script type="text/javascript" src="${portal_url}/++resource++NuPlone.libraries/jquery-1.11.3.min.js"></script>
+    <script type="text/javascript" src="${portal_url}/++resource++NuPlone.libraries/jquery.browser.min.js"></script>
+  <script type="text/javascript" src="${portal_url}/++resource++NuPlone.behaviour/behaviour.js"></script>
   <script tal:define="menu view/actions; url menu/url|nothing" tal:condition="not: url" type="text/javascript" meta:interpolation="false">
         $("a.contextActions").click(function(event) {
                 event.preventDefault();
@@ -106,4 +106,3 @@ sitemenu.init();
   </script>
   </body>
 </html>
-

--- a/plonetheme/nuplone/z3cform/templates/editlink.pt
+++ b/plonetheme/nuplone/z3cform/templates/editlink.pt
@@ -1,12 +1,12 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
     "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml"
-      xmlns:i18n="http://xml.zope.org/namespaces/i18n" 
+      xmlns:i18n="http://xml.zope.org/namespaces/i18n"
       xmlns:meta="http://xml.zope.org/namespaces/meta"
       xmlns:tal="http://xml.zope.org/namespaces/tal"
       meta:interpolation="true"
       i18n:domain="nuplone"
-      tal:define="tools context/@@tools">
+      tal:define="tools context/@@tools; portal_url tools/portal_url|nothing;">
   <head>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <link rel="stylesheet" type="text/css" media="all" href="${tools/portal/++resource++NuPlone.style}/form/base.css"/>
@@ -27,10 +27,10 @@
         </div>
       </form>
     </div>
-    <script type="text/javascript" src="${tools/portal/++resource++NuPlone.libraries}/rangy-core.js"></script>
-    <script type="text/javascript" src="${tools/portal/++resource++NuPlone.libraries}/jquery-1.11.3.min.js"></script>
-    <script type="text/javascript" src="${tools/portal/++resource++NuPlone.libraries}/jquery.browser.min.js"></script>
-    <script type="text/javascript" src="${tools/portal/++resource++NuPlone.libraries}/jquery.form.js"></script>
-    <script type="text/javascript" src="${tools/portal/++resource++NuPlone.behaviour}/editlink.js"></script>
+    <script type="text/javascript" src="${portal_url}/++resource++NuPlone.libraries/rangy-core.js"></script>
+    <script type="text/javascript" src="${portal_url}/++resource++NuPlone.libraries/jquery-1.11.3.min.js"></script>
+    <script type="text/javascript" src="${portal_url}/++resource++NuPlone.libraries/jquery.browser.min.js"></script>
+    <script type="text/javascript" src="${portal_url}/++resource++NuPlone.libraries/jquery.form.js"></script>
+    <script type="text/javascript" src="${portal_url}/++resource++NuPlone.behaviour/editlink.js"></script>
   </body>
 </html>

--- a/plonetheme/nuplone/z3cform/templates/toolbar.pt
+++ b/plonetheme/nuplone/z3cform/templates/toolbar.pt
@@ -6,7 +6,7 @@
       xmlns:i18n="http://xml.zope.org/namespaces/i18n"
       i18n:domain="nuplone"
       meta:interpolation="true"
-      tal:define="tools context/@@tools">
+      tal:define="tools context/@@tools; portal_url tools/portal_url|nothing;">
   <head>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <link rel="stylesheet" type="text/css" media="all" href="${tools/portal/++resource++NuPlone.style}/form/base.css"/>
@@ -35,8 +35,8 @@
         </fieldset>
       </div>
     </div>
-    <script type="text/javascript" src="${tools/portal/++resource++NuPlone.libraries}/jquery-1.11.3.min.js"></script>
-    <script type="text/javascript" src="${tools/portal/++resource++NuPlone.libraries}/jquery.browser.min.js"></script>
+    <script type="text/javascript" src="${portal_url}/++resource++NuPlone.libraries/jquery-1.11.3.min.js"></script>
+    <script type="text/javascript" src="${portal_url}/++resource++NuPlone.libraries/jquery.browser.min.js"></script>
     <script type="text/javascript">
       var plone = { portal_url : '${tools/portal/absolute_url}',
                     context_url : '${context/absolute_url}' };
@@ -86,4 +86,3 @@
     </script>
   </body>
 </html>
-


### PR DESCRIPTION
`${tools/portal/++resource++NuPlone.libraries}` is not working properly on Plone 5.1.
Also I think that defining once portal_url and reusing it is more efficient than always traversing the same path over and over.