### PR TITLE
Validation errors from invariants

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -4,7 +4,7 @@ Changelog
 1.6.3 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Show validation errors that are not associated with a widget (like invariants).
 
 
 1.6.2 (2019-08-21)

--- a/plonetheme/nuplone/z3cform/templates/wrappedform.pt
+++ b/plonetheme/nuplone/z3cform/templates/wrappedform.pt
@@ -10,6 +10,17 @@
      tal:condition="status"
      class="message ${python:'error' if view.widgets.errors else 'notice'}"
      i18n:domain="plone" i18n:translate="">${status}</p>
+  <tal:errors define="errors view/widgets/errors" condition="errors">
+      <tal:error repeat="error errors">
+          <p class="message field error"
+                  tal:condition="not:nocall:error/widget"
+                  tal:content="structure error/message"
+                  i18n:translate=""
+                  i18n:domain="plone">
+                  Error
+          </p>
+      </tal:error>
+  </tal:errors>
     <p class="discrete" tal:condition="python:getattr(view, 'description', None)">${view/description}</p>
   <form class="concise" action="${request/getURL}" enctype="${view/enctype}" method="${view/method}" id="${view/id}">
     <fieldset>


### PR DESCRIPTION
Show validation errors that are not associated with a widget (like invariants).
Closes #15 