### PR TITLE
Fix error sending emails with servers that have a long hostname

### DIFF
--- a/plonetheme/nuplone/utils.py
+++ b/plonetheme/nuplone/utils.py
@@ -177,7 +177,6 @@ def createEmailTo(
     else:
         mail["To"] = recipient_email
     mail["Subject"] = Header(subject.encode("utf-8"), "utf-8")
-    mail["Message-Id"] = emailutils.make_msgid()
     mail["Date"] = emailutils.formatdate(localtime=True)
     mail.set_param("charset", "utf-8")
 


### PR DESCRIPTION
The generated message id header was returning for hosts with a very long
name:

ValueError: Malformed Message-Id header

We actually do not need to send it because it will be autogenerated by
lower level code.