### PR TITLE
Remove the action parameter from the pat-depends config for z3c.form widgets

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -4,6 +4,17 @@ Changelog
 2.2.3 (unreleased)
 ------------------
 
+- Remove the action parameter from the pat-depends config for z3c.form widgets.
+  It was only switching between "show" and "hide", where "show" is the default
+  and "hide" doesn't exist. Having the action option set for pat-depends on
+  this level for no good reason prevents it from being overridable from a
+  parent element. Specifically we want to override the action default "show"
+  with "both" which shows/hides and enables/disables inputs. Input fields not
+  shown via pat-depends should also be disabled, so they are not submitted and
+  do not participate in form validation.
+  Ref: scrum-2615.
+  [thet]
+
 - Provide helper methods for the widgets that can be used to render
   patternslib specific markup
   [ale-rt]

--- a/plonetheme/nuplone/z3cform/directives.py
+++ b/plonetheme/nuplone/z3cform/directives.py
@@ -108,7 +108,7 @@ class WidgetDependencyView:
                 name = "%s:list" % name
 
             if dependency.op in ("on", "off"):
-                parts.append(f"condition: {name}")
+                parts.append(f"condition: {name}; action: both")
             elif dependency.op in ("==", "!="):
                 parts.append(f"condition: {name}={dependency.value}")
 

--- a/plonetheme/nuplone/z3cform/directives.py
+++ b/plonetheme/nuplone/z3cform/directives.py
@@ -110,7 +110,7 @@ class WidgetDependencyView:
             if dependency.op in ("on", "off"):
                 parts.append(f"condition: {name}; action: both")
             elif dependency.op in ("==", "!="):
-                parts.append(f"condition: {name}={dependency.value}")
+                parts.append(f"condition: {name}={dependency.value}; action: both")
 
         return "; ".join(parts) if parts else None
 

--- a/plonetheme/nuplone/z3cform/directives.py
+++ b/plonetheme/nuplone/z3cform/directives.py
@@ -107,14 +107,10 @@ class WidgetDependencyView:
             if isinstance(widget, CheckBoxWidget):
                 name = "%s:list" % name
 
-            if dependency.op == "on":
-                parts.append(f"condition: {name}; action: show")
-            elif dependency.op == "off":
-                parts.append(f"condition: {name}; action: hide")
-            elif dependency.op == "==":
-                parts.append(f"condition: {name}={dependency.value}; action: show")
-            elif dependency.op == "!=":
-                parts.append(f"condition: {name}={dependency.value}; action: hide")
+            if dependency.op in ("on", "off"):
+                parts.append(f"condition: {name}")
+            elif dependency.op in ("==", "!="):
+                parts.append(f"condition: {name}={dependency.value}")
 
         return "; ".join(parts) if parts else None
 


### PR DESCRIPTION
It was only switching between "show" and "hide", where "show" is the default and "hide" doesn't exist. Having the action option set for pat-depends on this level for no good reason prevents it from being overridable from a parent element. Specifically we want to override the action default "show" with "both" which shows/hides and enables/disables inputs. Input fields not shown via pat-depends should also be disabled, so they are not submitted and do not participate in form validation.

Ref: scrum-2615.

This needs:
https://github.com/quaive/quaive.resources.ploneintranet/pull/110
https://github.com/quaive/quaive.resources.ploneintranet/pull/114
https://github.com/euphorie/NuPlone/pull/53
https://github.com/euphorie/osha.oira/pull/295

