### PR TITLE
Set pat-depends action parameter to "both", fix unequal-comparisons.

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -4,6 +4,9 @@ Changelog
 2.2.3 (unreleased)
 ------------------
 
+- Fix the pat-depends condition for unequal-comparisons.
+  [thet, ale-rt]
+
 - Set the pat-depends action parameter for z3c.form widgets to "both" to also
   disable the input fields if they are hidden by pat-depends.
   Ref: scrum-2615.

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -4,6 +4,11 @@ Changelog
 2.2.3 (unreleased)
 ------------------
 
+- Set the pat-depends action parameter for z3c.form widgets to "both" to also
+  disable the input fields if they are hidden by pat-depends.
+  Ref: scrum-2615.
+  [thet]
+
 - Provide helper methods for the widgets that can be used to render
   patternslib specific markup
   [ale-rt]

--- a/plonetheme/nuplone/z3cform/directives.py
+++ b/plonetheme/nuplone/z3cform/directives.py
@@ -110,11 +110,11 @@ class WidgetDependencyView:
             if dependency.op == "on":
                 parts.append(f"condition: {name}; action: both")
             elif dependency.op == "off":
-                parts.append(f"condition: {name}; action: both")
+                parts.append(f"condition: not {name}; action: both")
             elif dependency.op == "==":
                 parts.append(f"condition: {name}={dependency.value}; action: both")
             elif dependency.op == "!=":
-                parts.append(f"condition: {name}={dependency.value}; action: both")
+                parts.append(f"condition: not {name}={dependency.value}; action: both")
 
         return "; ".join(parts) if parts else None
 

--- a/plonetheme/nuplone/z3cform/directives.py
+++ b/plonetheme/nuplone/z3cform/directives.py
@@ -108,13 +108,13 @@ class WidgetDependencyView:
                 name = "%s:list" % name
 
             if dependency.op == "on":
-                parts.append(f"condition: {name}; action: show")
+                parts.append(f"condition: {name}; action: both")
             elif dependency.op == "off":
-                parts.append(f"condition: {name}; action: hide")
+                parts.append(f"condition: {name}; action: both")
             elif dependency.op == "==":
-                parts.append(f"condition: {name}={dependency.value}; action: show")
+                parts.append(f"condition: {name}={dependency.value}; action: both")
             elif dependency.op == "!=":
-                parts.append(f"condition: {name}={dependency.value}; action: hide")
+                parts.append(f"condition: {name}={dependency.value}; action: both")
 
         return "; ".join(parts) if parts else None
 


### PR DESCRIPTION
- Fix the pat-depends condition for unequal-comparisons.

- Set the pat-depends action parameter for z3c.form widgets to "both" to also
  disable the input fields if they are hidden by pat-depends.
  

Ref: scrum-2615.

Follow-up and correction of: https://github.com/euphorie/NuPlone/pull/53