### PR TITLE
Fix an issue when we are looking up context aware vocabularies

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -4,6 +4,9 @@ Changelog
 2.2.3 (unreleased)
 ------------------
 
+- Fix an issue when we are looking up context aware vocabularies
+  [ale-rt]
+
 - Fix the pat-depends condition for unequal-comparisons.
   [thet, ale-rt]
 
@@ -552,4 +555,3 @@ This version is built for Plone 5.1 and higher!
 
 - First release.
   [wichert, cornae]
-

--- a/plonetheme/nuplone/z3cform/utils.py
+++ b/plonetheme/nuplone/z3cform/utils.py
@@ -1,3 +1,4 @@
+from plone import api
 from zope.schema.vocabulary import getVocabularyRegistry
 from zope.schema.vocabulary import VocabularyRegistryError
 
@@ -9,5 +10,12 @@ def getVocabulary(field):
     vr = getVocabularyRegistry()
     try:
         return vr.get(None, field.vocabularyName)
+    except AttributeError:
+        # Most probably it is safe to always pass the portal to vr.get.
+        # Anyway this patch minimizes the risk of breaking something.
+        try:
+            return vr.get(api.portal.get(), field.vocabularyName)
+        except VocabularyRegistryError:
+            return None
     except VocabularyRegistryError:
         return None


### PR DESCRIPTION
Example traceback:
```
2025-01-20 14:37:25,068 ERROR   [Zope.SiteErrorLog:36][waitress-2] AttributeError: http://192.168.125.10:9105/tool-creator/++contextportlets++plone.footerportlets/actions/edit             Traceback (innermost last):                                                                                                                                                                 
  Module ZPublisher.WSGIPublisher, line 181, in transaction_pubevents                                                                                                                       
  Module ZPublisher.WSGIPublisher, line 390, in publish_module                                                                                                                                Module ZPublisher.WSGIPublisher, line 284, in publish                                                                                                                                     
  Module ZPublisher.mapply, line 98, in mapply                                                                                                                                              
  Module ZPublisher.WSGIPublisher, line 68, in call_object                                                                                                                                    Module plone.app.portlets.browser.formhelper, line 177, in __call__                                                                                                                       
  Module z3c.form.form, line 238, in __call__                                                                                                                                               
  Module plone.z3cform.fieldsets.extensible, line 62, in update                                                                                                                               Module plone.z3cform.patch, line 31, in GroupForm_update                                                                                                                                  
  Module z3c.form.group, line 133, in update                                                                                                                                                
  Module z3c.form.form, line 140, in updateWidgets                                                                                                                                          
  Module z3c.form.field, line 257, in update                                                                                                                                                  Module zope.component._api, line 111, in getMultiAdapter                                                                                                                                  
  Module zope.component._api, line 126, in queryMultiAdapter                                                                                                                                
  Module zope.interface.registry, line 373, in queryMultiAdapter                                                                                                                              Module zope.interface.adapter, line 859, in queryMultiAdapter                                                                                                                             
  Module osha.oira.nuplone.widget, line 29, in ChoiceWidgetFactory                                                                                                                          
  Module plonetheme.nuplone.z3cform.utils, line 11, in getVocabulary                                                                                                                          Module Zope2.App.schema, line 32, in get                                                                                                                                                  
  Module plone.app.vocabularies.actions, line 20, in __call__                                                                                                                               
AttributeError: 'NoneType' object has no attribute 'portal_url'
```