### PR TITLE
Copy the the WysiwygWidget from plone.app.widgets

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -4,7 +4,10 @@ Changelog
 4.0.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Copy the the WysiwygWidget from plone.app.widgets 4.3 branch to NuPlone.
+  The widget has been deprecated since a long time and since plone.app.z3cform 4.4
+  it is an alias of the plone.app.z3cform.widgets.richtext.RichTextWidget.
+  [ale-rt]
 
 
 4.0.0 (2025-03-25)

--- a/plonetheme/nuplone/z3cform/configure.zcml
+++ b/plonetheme/nuplone/z3cform/configure.zcml
@@ -102,12 +102,26 @@
     template="templates/object_input.pt"
     />
 
+  <class class=".widget.WysiwygWidget">
+    <require
+        permission="zope.Public"
+        interface=".widget.IWysiwygWidget"
+        />
+  </class>
+
   <z3c:widgetTemplate
     mode="input"
-    widget="plone.app.z3cform.wysiwyg.widget.IWysiwygWidget"
+    widget=".widget.IWysiwygWidget"
     layer=".interfaces.INuPloneFormLayer"
     template="templates/wysiwyg_input.pt"
     />
+
+  <z3c:widgetTemplate
+      widget=".widget.IWysiwygWidget"
+      template="templates/wysiwyg_display.pt"
+      layer="z3c.form.interfaces.IFormLayer"
+      mode="display"
+      />
 
   <configure zcml:condition="installed collective.z3cform.datetimewidget">
     <z3c:widgetTemplate

--- a/plonetheme/nuplone/z3cform/templates/wysiwyg_display.pt
+++ b/plonetheme/nuplone/z3cform/templates/wysiwyg_display.pt
@@ -1,0 +1,22 @@
+<div class=""
+     id=""
+     tal:attributes="
+       id view/id;
+       class view/klass;
+       style view/style;
+       title view/title;
+       lang view/lang;
+       onclick view/onclick;
+       ondblclick view/ondblclick;
+       onmousedown view/onmousedown;
+       onmouseup view/onmouseup;
+       onmouseover view/onmouseover;
+       onmousemove view/onmousemove;
+       onmouseout view/onmouseout;
+       onkeypress view/onkeypress;
+       onkeydown view/onkeydown;
+       onkeyup view/onkeyup;
+     "
+><tal:block condition="view/value"
+             content="structure view/value"
+  /></div>

--- a/plonetheme/nuplone/z3cform/widget.py
+++ b/plonetheme/nuplone/z3cform/widget.py
@@ -15,9 +15,18 @@ from z3c.form.widget import FieldWidget
 from ZODB.POSException import POSKeyError
 from zope.component import adapter
 from zope.component import getMultiAdapter
+from zope.component.hooks import getSite
 from zope.interface import implementer
+from zope.interface import implementer_only
 from zope.schema.interfaces import IChoice
 from ZPublisher.HTTPRequest import FileUpload
+
+import Acquisition
+import z3c.form.browser.textarea
+import z3c.form.interfaces
+import z3c.form.widget
+import zope.interface
+import zope.schema.interfaces
 
 
 class SingleRadioWidget(RadioWidget):
@@ -137,3 +146,49 @@ class NicerNamedFileWidget(NamedFileWidget):
 @implementer(IFieldWidget)
 def NamedFileWidgetFactory(field, request):
     return FieldWidget(field, NicerNamedFileWidget(request))
+
+
+class IWysiwygWidget(z3c.form.interfaces.ITextAreaWidget):
+    """This is a copy of plone.app.z3cform.wysiwyg.widget.IWysiwygWidget
+    from the 4.3 branch.
+
+    Since 4.4 the widget has been removed.
+    """
+
+    pass
+
+
+@implementer_only(IWysiwygWidget)
+class WysiwygWidget(z3c.form.browser.textarea.TextAreaWidget):
+    """This is a copy of plone.app.z3cform.wysiwyg.widget.WysiwygWidget
+    from the 4.3 branch.
+
+    Since 4.4 the widget has been removed.
+    """
+
+    klass = "kupu-widget"
+    value = ""
+
+    def update(self):
+        super(z3c.form.browser.textarea.TextAreaWidget, self).update()
+        z3c.form.browser.widget.addFieldClass(self)
+        # We'll wrap context in the current site *if* it's not already
+        # wrapped.  This allows the template to acquire tools with
+        # ``context/portal_this`` if context is not wrapped already.
+        # Any attempts to satisfy the Kupu template in a less idiotic
+        # way failed:
+        if getattr(self.form.context, "aq_inner", None) is None:
+            self.form.context = Acquisition.ImplicitAcquisitionWrapper(
+                self.form.context, getSite()
+            )
+
+
+@adapter(zope.schema.interfaces.IField, z3c.form.interfaces.IFormLayer)
+@implementer(z3c.form.interfaces.IFieldWidget)
+def WysiwygFieldWidget(field, request):
+    """This is a copy of plone.app.z3cform.wysiwyg.widget.WysiwygFieldWidget
+    from the 4.3 branch.
+
+    Since 4.4 the widget has been removed.
+    """
+    return z3c.form.widget.FieldWidget(field, WysiwygWidget(request))


### PR DESCRIPTION
Copy the the WysiwygWidget from plone.app.widgets 4.3 branch to NuPlone. 
The widget has been deprecated since a long time and since plone.app.z3cform 4.4 it is an alias of the plone.app.z3cform.widgets.richtext.RichTextWidget which is not good for us.