### PR TITLE
Fix a problem with the WYSIWYG widget registration.

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -4,6 +4,13 @@ Changelog
 4.0.2 (unreleased)
 ------------------
 
+- Fix a problem with the WYSIWYG widget registration.
+  Allow to check for a zcml:condition if the new WYSIWYG display widget is
+  available. This can then be used to conditionally register a more specific
+  widget implementation, e.g. in osha.oira.nuplone.
+  Ref: scrum-3433.
+  [thet]
+
 - Modernize imports.
   [ale-rt]
 

--- a/plonetheme/nuplone/z3cform/configure.zcml
+++ b/plonetheme/nuplone/z3cform/configure.zcml
@@ -102,22 +102,22 @@
     template="templates/object_input.pt"
     />
 
-  <class class=".widget.WysiwygWidget">
+  <class class=".wysiwyg.WysiwygWidget">
     <require
         permission="zope.Public"
-        interface=".widget.IWysiwygWidget"
+        interface=".wysiwyg.IWysiwygWidget"
         />
   </class>
 
   <z3c:widgetTemplate
     mode="input"
-    widget=".widget.IWysiwygWidget"
+    widget=".wysiwyg.IWysiwygWidget"
     layer=".interfaces.INuPloneFormLayer"
     template="templates/wysiwyg_input.pt"
     />
 
   <z3c:widgetTemplate
-      widget=".widget.IWysiwygWidget"
+      widget=".wysiwyg.IWysiwygWidget"
       template="templates/wysiwyg_display.pt"
       layer="z3c.form.interfaces.IFormLayer"
       mode="display"

--- a/plonetheme/nuplone/z3cform/widget.py
+++ b/plonetheme/nuplone/z3cform/widget.py
@@ -15,18 +15,9 @@ from z3c.form.widget import FieldWidget
 from ZODB.POSException import POSKeyError
 from zope.component import adapter
 from zope.component import getMultiAdapter
-from zope.component.hooks import getSite
 from zope.interface import implementer
-from zope.interface import implementer_only
 from zope.schema.interfaces import IChoice
 from ZPublisher.HTTPRequest import FileUpload
-
-import Acquisition
-import z3c.form.browser.textarea
-import z3c.form.interfaces
-import z3c.form.widget
-import zope.interface
-import zope.schema.interfaces
 
 
 class SingleRadioWidget(RadioWidget):
@@ -146,49 +137,3 @@ class NicerNamedFileWidget(NamedFileWidget):
 @implementer(IFieldWidget)
 def NamedFileWidgetFactory(field, request):
     return FieldWidget(field, NicerNamedFileWidget(request))
-
-
-class IWysiwygWidget(z3c.form.interfaces.ITextAreaWidget):
-    """This is a copy of plone.app.z3cform.wysiwyg.widget.IWysiwygWidget
-    from the 4.3 branch.
-
-    Since 4.4 the widget has been removed.
-    """
-
-    pass
-
-
-@implementer_only(IWysiwygWidget)
-class WysiwygWidget(z3c.form.browser.textarea.TextAreaWidget):
-    """This is a copy of plone.app.z3cform.wysiwyg.widget.WysiwygWidget
-    from the 4.3 branch.
-
-    Since 4.4 the widget has been removed.
-    """
-
-    klass = "kupu-widget"
-    value = ""
-
-    def update(self):
-        super(z3c.form.browser.textarea.TextAreaWidget, self).update()
-        z3c.form.browser.widget.addFieldClass(self)
-        # We'll wrap context in the current site *if* it's not already
-        # wrapped.  This allows the template to acquire tools with
-        # ``context/portal_this`` if context is not wrapped already.
-        # Any attempts to satisfy the Kupu template in a less idiotic
-        # way failed:
-        if getattr(self.form.context, "aq_inner", None) is None:
-            self.form.context = Acquisition.ImplicitAcquisitionWrapper(
-                self.form.context, getSite()
-            )
-
-
-@adapter(zope.schema.interfaces.IField, z3c.form.interfaces.IFormLayer)
-@implementer(z3c.form.interfaces.IFieldWidget)
-def WysiwygFieldWidget(field, request):
-    """This is a copy of plone.app.z3cform.wysiwyg.widget.WysiwygFieldWidget
-    from the 4.3 branch.
-
-    Since 4.4 the widget has been removed.
-    """
-    return z3c.form.widget.FieldWidget(field, WysiwygWidget(request))

--- a/plonetheme/nuplone/z3cform/wysiwyg.py
+++ b/plonetheme/nuplone/z3cform/wysiwyg.py
@@ -1,0 +1,55 @@
+from zope.component import adapter
+from zope.component.hooks import getSite
+from zope.interface import implementer
+from zope.interface import implementer_only
+
+import Acquisition
+import z3c.form
+import zope.schema
+
+
+class IWysiwygWidget(z3c.form.interfaces.ITextAreaWidget):
+    """This is a copy of plone.app.z3cform.wysiwyg.widget.IWysiwygWidget
+    from the 4.3 branch.
+
+    Since 4.4 the widget has been removed.
+    """
+
+    pass
+
+
+@implementer_only(IWysiwygWidget)
+class WysiwygWidget(z3c.form.browser.textarea.TextAreaWidget):
+    """This is a copy of plone.app.z3cform.wysiwyg.widget.WysiwygWidget
+    from the 4.3 branch.
+
+    Since 4.4 the widget has been removed.
+    """
+
+    klass = "kupu-widget"
+    value = ""
+
+    def update(self):
+        breakpoint()
+        super(z3c.form.browser.textarea.TextAreaWidget, self).update()
+        z3c.form.browser.widget.addFieldClass(self)
+        # We'll wrap context in the current site *if* it's not already
+        # wrapped.  This allows the template to acquire tools with
+        # ``context/portal_this`` if context is not wrapped already.
+        # Any attempts to satisfy the Kupu template in a less idiotic
+        # way failed:
+        if getattr(self.form.context, "aq_inner", None) is None:
+            self.form.context = Acquisition.ImplicitAcquisitionWrapper(
+                self.form.context, getSite()
+            )
+
+
+@adapter(zope.schema.interfaces.IField, z3c.form.interfaces.IFormLayer)
+@implementer(z3c.form.interfaces.IFieldWidget)
+def WysiwygFieldWidget(field, request):
+    """This is a copy of plone.app.z3cform.wysiwyg.widget.WysiwygFieldWidget
+    from the 4.3 branch.
+
+    Since 4.4 the widget has been removed.
+    """
+    return z3c.form.widget.FieldWidget(field, WysiwygWidget(request))

--- a/plonetheme/nuplone/z3cform/wysiwyg.py
+++ b/plonetheme/nuplone/z3cform/wysiwyg.py
@@ -32,7 +32,6 @@ class WysiwygWidget(z3c.form.browser.textarea.TextAreaWidget):
     value = ""
 
     def update(self):
-        breakpoint()
         super(z3c.form.browser.textarea.TextAreaWidget, self).update()
         z3c.form.browser.widget.addFieldClass(self)
         # We'll wrap context in the current site *if* it's not already

--- a/plonetheme/nuplone/z3cform/wysiwyg.py
+++ b/plonetheme/nuplone/z3cform/wysiwyg.py
@@ -4,7 +4,9 @@ from zope.interface import implementer
 from zope.interface import implementer_only
 
 import Acquisition
-import z3c.form
+import z3c.form.browser.textarea
+import z3c.form.interfaces
+import z3c.form.widget
 import zope.schema
 
 


### PR DESCRIPTION
NOTE:
I think this approach is better:
https://github.com/euphorie/Euphorie/pull/840 + 3 other PRs

Allow to check for a `zcml:condition` if the new WYSIWYG display widget is available. This can then be used to conditionally register a more specific widget implementation, e.g. in osha.oira.nuplone.

The previous `zcml:condition` used in osha.oira and elsewhere were not working, because `IWysiwygWidget` class cannot be imported directly from a module like so:
```
zcml:condition="installed plonetheme.nuplone.z3cform.widget.IWysiwygWidget"
```

We can only import the module directly - therefore I created a new module:
```
zcml:condition="installed plonetheme.nuplone.z3cform.wysiwyg"
```

Ref: scrum-3433.

# PRs

- https://github.com/euphorie/NuPlone/pull/60
- https://github.com/euphorie/Euphorie/pull/839
- https://github.com/euphorie/osha.oira/pull/331
- https://github.com/syslabcom/daimler.oira/pull/369
- https://github.com/euphorie/tno.euphorie/pull/22